### PR TITLE
Replace Leaf crash with kill

### DIFF
--- a/src/leaf/src/leaf.rs
+++ b/src/leaf/src/leaf.rs
@@ -20,7 +20,7 @@ pub trait Leaf: Send {
 #[derive(Debug, Clone)]
 pub enum LeafEvent {
     PacketSend(Packet),
-    // Used expecially for FloodResponse but also
+    // Used especially for FloodResponse but also
     // if all other methods of sending ack/nack fail
     ControllerShortcut(Packet),
 }
@@ -29,5 +29,5 @@ pub enum LeafEvent {
 pub enum LeafCommand {
     RemoveSender(NodeId),
     AddSender(NodeId, Sender<Packet>),
-    Crash,
+    Kill, // Stop blocking the thread on which this leaf is run, used for testing only
 }


### PR DESCRIPTION
Leafs should not crash, as this will cause servers to become unresponsive. Clients are unable to detect if a server has crashed. Including this possibility complicates their logic or results in a confusing user experience.

Unblocking the thread the leaf is run on is still useful for testing purposes. Hence the "Crash" command is replaced with "Kill" which will satisfy this purpose from now on. This command should never be issued outside of testing.

The renaming of the command will better align programmer expectations and reduce confusion.