### PR TITLE
Add server uuid to text and media

### DIFF
--- a/src/message/src/lib.rs
+++ b/src/message/src/lib.rs
@@ -9,11 +9,14 @@ use wg_2024::network::NodeId;
 pub type Link = String;
 pub type Media = Vec<u8>;
 
+/// Allowing servers to be identified throughout different topologies, where they get assigned different NodeIds.
+pub type ServerUUID = u64;
+
 #[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ServerType {
     Chat,
-    Text,
-    Media,
+    Text(ServerUUID),
+    Media(ServerUUID),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -21,5 +24,5 @@ pub struct FileWithData {
     pub file: String,
     // For each link which server to get the data from
     // Data is both file and media
-    pub related_data: HashMap<Link, NodeId>,
+    pub related_data: HashMap<Link, ServerUUID>,
 }


### PR DESCRIPTION
Allow text and media server to link through a ServerUUID, to not depend on the unknown NodeId they will get assigned in a topology.

The client is responsible for finding the NodeId of the server with that UUID. The UUIDs are unique for every server, but in case a server is present twice in the network, they can have the same UUID, as long as they contain the same content. It does not make a difference which server is requested the resource in that case.